### PR TITLE
Provide stack name 

### DIFF
--- a/stack/builder
+++ b/stack/builder
@@ -50,6 +50,7 @@ fi
 
 # generate a random request id used by buildpack instrumentation
 export REQUEST_ID=$(openssl rand -base64 32)
+export STACK=cedar
 
 $selected_buildpack/bin/compile "$build_root" "$cache_root"
 


### PR DESCRIPTION
The newer heroku ruby buildpackes (after heroku/heroku-buildpack-ruby@3e01277) use the STACK
variable for caching and cache busting. Without the STACK envvar the bundler cache will be emptied on each deploy and cause all gems to be redownloaded.
