### PR TITLE
Add test for plain Ruby app with MRI 2.1.3

### DIFF
--- a/tests/ruby/Gemfile
+++ b/tests/ruby/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+ruby '2.1.3'
+
+gem 'sinatra', '~>1.4.4'
+gem 'thin'

--- a/tests/ruby/Gemfile.lock
+++ b/tests/ruby/Gemfile.lock
@@ -1,0 +1,24 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    daemons (1.1.9)
+    eventmachine (1.0.3)
+    rack (1.5.2)
+    rack-protection (1.5.2)
+      rack
+    sinatra (1.4.4)
+      rack (~> 1.4)
+      rack-protection (~> 1.4)
+      tilt (~> 1.3, >= 1.3.4)
+    thin (1.6.1)
+      daemons (>= 1.0.9)
+      eventmachine (>= 1.0.0)
+      rack (>= 1.0.0)
+    tilt (1.4.1)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  sinatra (~> 1.4.4)
+  thin

--- a/tests/ruby/Procfile
+++ b/tests/ruby/Procfile
@@ -1,0 +1,1 @@
+web: bundle exec ruby web.rb -p $PORT

--- a/tests/ruby/check_deploy
+++ b/tests/ruby/check_deploy
@@ -1,0 +1,2 @@
+#!/bin/bash
+set -e; output="$(curl --verbose --fail -x "$2" $1)"; echo $output; test "$output" == "Chunky bacon"

--- a/tests/ruby/web.rb
+++ b/tests/ruby/web.rb
@@ -1,0 +1,5 @@
+require 'sinatra'
+
+get '/' do
+  'Chunky bacon'
+end

--- a/wercker.yml
+++ b/wercker.yml
@@ -31,5 +31,8 @@ build:
         name: run python-flask tests
         code: tests/run_tests python-flask
     - script:
+        name: run ruby tests
+        code: tests/run_tests ruby
+    - script:
         name: run static tests
         code: tests/run_tests static


### PR DESCRIPTION
Heroku recently changed the base URL for prebuilt binaries from S3 (see https://github.com/heroku/heroku-buildpack-ruby/issues/304), so older versions of Ruby buildpack will fail when attempting to download the latest version of Ruby. I have added this test to verify both that Ruby buildpack is working and correct S3 URLs are being used.
