### PR TITLE
Fix escaping

### DIFF
--- a/builder/builder
+++ b/builder/builder
@@ -52,7 +52,7 @@ hash -r
 case "\$(basename \$0)" in
   start)
     if [[ -f Procfile ]]; then
-      command="foreman start --procfile=Procfile \"\$1\""
+      command="foreman start --procfile=Procfile \$@"
     else
       command="\$(ruby -e "require 'yaml';puts (YAML.load_file('.release')['default_process_types'] || {})['\$1']")"
     fi


### PR DESCRIPTION
Without this the following is written to the image:

command="foreman start --procfile=Procfile \"\""
